### PR TITLE
Ensure the defined MAVEN_HOME has the binary

### DIFF
--- a/src/main/bash/all-integration-tests.sh
+++ b/src/main/bash/all-integration-tests.sh
@@ -27,7 +27,7 @@ if [ -n "${JAVA_HOME}" ]; then
    java -version
 fi
 
-if [ -z "${MAVEN_HOME}" ]; then
+if [ -z "${MAVEN_HOME}" i] || [ ! -e "${MAVEN_HOME}/bin/mvn" ]; then
   echo "No Maven Home defined - setting to default: ${DEFAULT_MAVEN_HOME}"
   export MAVEN_HOME=${DEFAULT_MAVEN_HOME}
   if [ ! -d  "${DEFAULT_MAVEN_HOME}" ]; then


### PR DESCRIPTION
The issue here is that, sometimes, if the MAVEN_HOME has been set, the actually binaries are not download (especially the first time you run some projects within a docker container). This change ensures that if the MAVEN_HOME is defined but contains no '/bin/mvn', the script will try to use the usual "download tools" of the Wildfly build. 